### PR TITLE
Increasing scanner buffer size from default 4096 to 1M, to handle large files

### DIFF
--- a/front.go
+++ b/front.go
@@ -69,7 +69,13 @@ func sniffDelim(input []byte) (string, error) {
 }
 
 func (m *Matter) splitFront(input io.Reader) (front, body string, err error) {
+	bufsize := 1024 * 1024
+	buf := make([]byte, bufsize)
+
 	s := bufio.NewScanner(input)
+	// Necessary so we can handle larger than default 4096b buffer
+	s.Buffer(buf, bufsize)
+
 	rst := make([]string, 2)
 	s.Split(m.split)
 	n := 0


### PR DESCRIPTION
This blows up if the input file is > 4096 bytes which is the Scanner default buffer size. I started playing with some other options including going down the road of using bufio.Reader (Scanner docs recommend using this for large tokens), alas, life is short and Trump is soon to be President, so I decided to simply increase the Scanner buffer to a hardcoded 1M. Feel free to come up with something more elegant if you like.