### PR TITLE
Fixed and cleaned up "How to use" code in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ extracts frontmatter from text files with ease.
 
 	go get github.com/gernest/front
 
-## How To use
+## How to use
 
 ```go
 package main
@@ -24,10 +24,9 @@ import (
 	"github.com/gernest/front"
 )
 
-var txt = `
-+++
+var txt = `+++
 {
-	"title":"front"
+    "title":"front"
 }
 +++
 
@@ -40,13 +39,12 @@ func main() {
 	m.Handle("+++", front.JSONHandler)
 	f, body, err := m.Parse(strings.NewReader(txt))
 	if err != nil {
-		// Handle error here
+		panic(err)
 	}
 
-	fmt.Printf("The front matter is %v \n", f)
-	fmt.Println("The body is %s \n", body)
+	fmt.Printf("The front matter is:\n%#v\n", f)
+	fmt.Printf("The body is:\n%q\n", body)
 }
-
 ```
 
 Please see the tests formore details


### PR DESCRIPTION
 - Fixed text input (var txt.) It was broken because it started with a newline character.
 - Fixed text output. fmt.Println() was being used with format specifiers.