### PR TITLE
Incorrect splitting when body contains delimiter

### DIFF
--- a/front_test.go
+++ b/front_test.go
@@ -42,3 +42,26 @@ func TestYAMLHandler(t *testing.T) {
 		t.Errorf("expected language got nil instead")
 	}
 }
+
+func TestMultipleDelimiters(t *testing.T) {
+	bodyData, err := ioutil.ReadFile("testdata/multi/body.md")
+	if err != nil {
+		t.Error(err)
+	}
+	m := NewMatter()
+	m.Handle("---", YAMLHandler)
+	b, err := ioutil.ReadFile("testdata/multi/yaml.md")
+	if err != nil {
+		t.Error(err)
+	}
+	front, body, err := m.Parse(bytes.NewReader(b))
+	if err != nil {
+		t.Error(err)
+	}
+	if body != string(bodyData) {
+		t.Errorf("expected %s got %s", string(bodyData), body)
+	}
+	if _, ok := front["test"]; !ok {
+		t.Error("expected front matter to contain test got nil instead")
+	}
+}

--- a/testdata/multi/body.md
+++ b/testdata/multi/body.md
@@ -1,0 +1,5 @@
+Text
+
+---
+
+More text

--- a/testdata/multi/yaml.md
+++ b/testdata/multi/yaml.md
@@ -1,0 +1,9 @@
+---
+test: "hello"
+---
+
+Text
+
+---
+
+More text


### PR DESCRIPTION
When the body of a file contains a delimiter, incorrect parsing occurs.

I haven't yet found a good way to fix this (the use of `SplitFunc` makes it a bit difficult to reconstruct the original text and I have yet to figure out the best way to simply make it stop splitting), but for now here's a unit test to illustrate things.