### PR TITLE
don't panic on reading empty files

### DIFF
--- a/front.go
+++ b/front.go
@@ -52,6 +52,8 @@ func (m *Matter) parse(input io.Reader) (front map[string]interface{}, body stri
 	f, body, err := m.splitFront(input)
 	if err != nil {
 		return nil, "", err
+	} else if len(f) < 3 {
+		return map[string]interface{}{}, body, nil
 	}
 	h := m.handlers[f[:3]]
 	front, err = h(getFront(f))

--- a/front_test.go
+++ b/front_test.go
@@ -42,3 +42,23 @@ func TestYAMLHandler(t *testing.T) {
 		t.Errorf("expected language got nil instead")
 	}
 }
+
+func TestEmptyFile(t *testing.T) {
+	data, err := ioutil.ReadFile("testdata/front/empty.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	m := NewMatter()
+	m.Handle("+++", JSONHandler)
+	front, body, err := m.Parse(bytes.NewReader(data))
+	if err != nil {
+		t.Error(err)
+	}
+	if len(front) != 0 {
+		t.Fatal("front was not empty")
+	}
+	if len(body) != 0 {
+		t.Fatal("body was not empty")
+	}
+}


### PR DESCRIPTION
When the number of bytes in the file is less then 3, don't bother trying to match to a handler 